### PR TITLE
add backwards compatible version of Math.toIntExact

### DIFF
--- a/android/src/main/java/com/red5pro/reactnative/stream/R5StreamSubscriber.java
+++ b/android/src/main/java/com/red5pro/reactnative/stream/R5StreamSubscriber.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.red5pro.reactnative.view.PublishService;
 import com.red5pro.reactnative.view.R5VideoViewLayout;
 import com.red5pro.reactnative.view.SubscribeService;
+import com.red5pro.reactnative.util.MathUtil;
 import com.red5pro.streaming.R5Connection;
 import com.red5pro.streaming.R5Stream;
 import com.red5pro.streaming.R5StreamProtocol;
@@ -482,8 +483,8 @@ public class R5StreamSubscriber implements R5StreamInstance,
 					WritableMap statsMap = new WritableNativeMap();
 					statsMap.putDouble("buffered_time", stats.buffered_time);
 					statsMap.putDouble("subscribe_latency", stats.subscribe_latency);
-					statsMap.putInt("pkts_audio_dropped", Math.toIntExact(stats.pkts_audio_dropped));
-					statsMap.putInt("pkts_video_dropped", Math.toIntExact(stats.pkts_video_dropped));
+					statsMap.putInt("pkts_audio_dropped", MathUtil.toIntExact(stats.pkts_audio_dropped));
+					statsMap.putInt("pkts_video_dropped", MathUtil.toIntExact(stats.pkts_video_dropped));
 					statsMap.putDouble("bitrate_received_smoothed", stats.bitrate_received_smoothed);
 
 					// Emulate a regular stream subscriber event and piggyback on SUBSCRIBER_STATUS

--- a/android/src/main/java/com/red5pro/reactnative/util/MathUtil.java
+++ b/android/src/main/java/com/red5pro/reactnative/util/MathUtil.java
@@ -1,0 +1,14 @@
+package com.red5pro.reactnative.util;
+
+
+public class MathUtil {
+
+	// Android versions < 6 do not include the java.lang.Math.toIntExact
+	// See: https://stackoverflow.com/questions/60015731/android-version-compatibility-for-math-tointexact-utility-method
+	public static int toIntExact(long value) {
+		if ((int)value != value) {
+			throw new ArithmeticException("integer overflow");
+		}
+		return (int)value;
+	}
+}


### PR DESCRIPTION
# Purpose:
There is an issue with android < 6 not having toIntExact.
See https://stackoverflow.com/questions/60015731/android-version-compatibility-for-math-tointexact-utility-method